### PR TITLE
Hide manage subscription button when trialing

### DIFF
--- a/Frontend/src/components/Dashboard/Settings/settings.jsx
+++ b/Frontend/src/components/Dashboard/Settings/settings.jsx
@@ -308,13 +308,15 @@ const Settings = () => {
               </button>
             )}
 
-            <button
-              onClick={handleManageSubscription}
-              className="manage-subscription-btn"
-              disabled={processingSubscription}
-            >
-              {processingSubscription ? 'Chargement...' : 'Gérer mon abonnement'}
-            </button>
+            {subscription && subscription.status === SUBSCRIPTION_STATUS.ACTIVE && (
+              <button
+                onClick={handleManageSubscription}
+                className="manage-subscription-btn"
+                disabled={processingSubscription}
+              >
+                {processingSubscription ? 'Chargement...' : 'Gérer mon abonnement'}
+              </button>
+            )}
           </div>
         </section>
 

--- a/Frontend/src/pages/Settings/Index.jsx
+++ b/Frontend/src/pages/Settings/Index.jsx
@@ -304,13 +304,15 @@ const Settings = () => {
               </button>
             )}
 
-            <button
-              onClick={handleManageSubscription}
-              className="manage-subscription-btn"
-              disabled={processingSubscription}
-            >
-              {processingSubscription ? 'Chargement...' : 'Gérer mon abonnement'}
-            </button>
+            {subscription && subscription.status === SUBSCRIPTION_STATUS.ACTIVE && (
+              <button
+                onClick={handleManageSubscription}
+                className="manage-subscription-btn"
+                disabled={processingSubscription}
+              >
+                {processingSubscription ? 'Chargement...' : 'Gérer mon abonnement'}
+              </button>
+            )}
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- hide "Gérer mon abonnement" button while user is in trial period

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684870e2ab2c832dbffc5ed882d9e455