### PR TITLE
Remove deprecated download buttons

### DIFF
--- a/Frontend/src/components/Dashboard/BusinessCard/businessCard.jsx
+++ b/Frontend/src/components/Dashboard/BusinessCard/businessCard.jsx
@@ -523,24 +523,6 @@ const BusinessCard = ({ userId, user }) => {
                 <p className="save-status">✅ Image sauvegardée en base de données</p>
               )}
               
-              <div className="download-buttons">
-                <button 
-                  onClick={downloadCardImageOnly}
-                  className="download-image-btn"
-                  disabled={loading}
-                  title="Télécharger le template seul"
-                >
-                  📷 Template seul
-                </button>
-                <button 
-                  onClick={downloadBusinessCard}
-                  className="download-with-qr-btn"
-                  disabled={loading}
-                  title="Télécharger la carte complète"
-                >
-                  📥 Carte complète
-                </button>
-              </div>
             </div>
 
             <div className="form-group">

--- a/Frontend/src/components/Dashboard/BusinessCard/businessCard.scss
+++ b/Frontend/src/components/Dashboard/BusinessCard/businessCard.scss
@@ -632,58 +632,6 @@
 }
 
 /* ✅ Boutons de téléchargement dans le design */
-.download-buttons {
-  display: flex;
-  gap: 0.75rem;
-  margin-top: 1rem;
-  flex-wrap: wrap;
-}
-
-.download-image-btn,
-.download-with-qr-btn {
-  padding: 0.6rem 1.2rem;
-  border: none;
-  border-radius: 8px;
-  font-size: 0.85rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  flex: 1;
-  min-width: 120px;
-  justify-content: center;
-}
-
-.download-image-btn {
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-  color: white;
-}
-
-.download-image-btn:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
-}
-
-.download-with-qr-btn {
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
-  color: white;
-}
-
-.download-with-qr-btn:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 15px rgba(16, 185, 129, 0.3);
-}
-
-.download-image-btn:disabled,
-.download-with-qr-btn:disabled {
-  background: #64748b;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-  opacity: 0.6;
-}
 
 /* Aperçu de la carte */
 .card-preview {
@@ -1096,14 +1044,6 @@
     width: 100%;
   }
 
-  .download-buttons {
-    flex-direction: column;
-  }
-
-  .download-image-btn,
-  .download-with-qr-btn {
-    min-width: auto;
-  }
 
   .schemas-actions {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- remove the download buttons from the business card editor
- clean up related styles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68488327e23c832d86310a02ecbfe4ef