### PR TITLE
Avoid multiple sockets per user

### DIFF
--- a/Backend/app.js
+++ b/Backend/app.js
@@ -41,7 +41,16 @@ io.on("connection", (socket) => {
   socket.on("authenticate", (userId) => {
     if (userId) {
       console.log(`✅ Utilisateur ${userId} authentifié sur socket ${socket.id}`);
-      // Stocker la connexion de l'utilisateur
+      // Déconnecter l'ancienne connexion si elle existe
+      const previousSocketId = userConnections.get(userId);
+      if (previousSocketId && previousSocketId !== socket.id) {
+        const previousSocket = io.sockets.sockets.get(previousSocketId);
+        if (previousSocket) {
+          previousSocket.disconnect(true);
+        }
+      }
+
+      // Stocker la nouvelle connexion de l'utilisateur
       userConnections.set(userId, socket.id);
       // Rejoindre une room spécifique à l'utilisateur
       socket.join(`user-${userId}`);


### PR DESCRIPTION
## Summary
- disconnect older sockets when user authenticates again

## Testing
- `npm test` (fails: `Error: no test specified`)
- `npm run build` in Backend
- `npm test` in Frontend (fails: missing script)
- `npm run build` in Frontend (fails: vite not found)


------
https://chatgpt.com/codex/tasks/task_e_684881ae78d4832dabd576b740c0e8e0