### PR TITLE
Fix TTC calculation persistence

### DIFF
--- a/Backend/models/devis.js
+++ b/Backend/models/devis.js
@@ -28,7 +28,8 @@ const devisSchema = new mongoose.Schema({
       description: String,
       unitPrice: Number,
       quantity: Number,
-      unit: String
+      unit: String,
+      tvaRate: { type: Number, default: 20 }
     }
   ]
 });


### PR DESCRIPTION
## Summary
- store `tvaRate` for each article in quote schema
- add trailing newline to schema file

## Testing
- `node -e "require('./Backend/models/devis.js'); console.log('ok')"` *(fails: Cannot find module 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_6848837900f0832daad0bb03ccd726bc