### PR TITLE
Fix cancel buttons to show icon only

### DIFF
--- a/Frontend/src/components/Dashboard/Billing/DynamicInvoice.jsx
+++ b/Frontend/src/components/Dashboard/Billing/DynamicInvoice.jsx
@@ -564,8 +564,8 @@ const DynamicInvoice = ({
           💾 Enregistrer
         </button>
         {onCancel && (
-          <button onClick={onCancel} className="invoice-action-btn cancel-btn">
-            ✕ Annuler
+          <button onClick={onCancel} className="invoice-action-btn cancel-btn" title="Annuler">
+            ✕
           </button>
         )}
       </div>

--- a/Frontend/src/components/Dashboard/BusinessCard/businessCard.jsx
+++ b/Frontend/src/components/Dashboard/BusinessCard/businessCard.jsx
@@ -774,11 +774,12 @@ const BusinessCard = ({ userId, user }) => {
             </div>
             
             <div className="modal-footer">
-              <button 
+              <button
                 onClick={() => setShowSchemasModal(false)}
                 className="btn-cancel"
+                title="Annuler"
               >
-                Annuler
+                ✕
               </button>
             </div>
           </div>

--- a/Frontend/src/components/Dashboard/ClientBilling/InvoicePreview.jsx
+++ b/Frontend/src/components/Dashboard/ClientBilling/InvoicePreview.jsx
@@ -130,8 +130,8 @@ const InvoicePreview = ({ invoice, client, devisDetails = [], onSave, onCancel }
         <button onClick={handleSave} className="toolbar-btn save-btn">
           💾 Enregistrer
         </button>
-        <button onClick={onCancel} className="toolbar-btn cancel-btn">
-          ✕ Annuler
+        <button onClick={onCancel} className="toolbar-btn cancel-btn" title="Annuler">
+          ✕
         </button>
       </div>
 

--- a/Frontend/src/components/Dashboard/Prospects/prospectEditPage.jsx
+++ b/Frontend/src/components/Dashboard/Prospects/prospectEditPage.jsx
@@ -430,12 +430,13 @@ const ProspectEditPage = ({ prospect, onBack, onSave }) => {
 
           {/* Actions */}
           <div className="form-actions">
-            <button 
-              type="button" 
+            <button
+              type="button"
               onClick={onBack || (() => navigate(-1))}
               className="btn-cancel"
+              title="Annuler"
             >
-              Annuler
+              ✕
             </button>
             
             <button 

--- a/Frontend/src/pages/Login/Index.jsx
+++ b/Frontend/src/pages/Login/Index.jsx
@@ -164,9 +164,9 @@ const Login = () => {
                     type="button"
                     className="password-toggle"
                     onClick={() => setShowPassword(!showPassword)}
-                    title={showPassword ? "Masquer le mot de passe" : "Afficher le mot de passe"}
+                    title={showPassword ? "Masquer" : "Afficher"}
                   >
-                    {showPassword ? "👁️" : "👁️‍🗨️"}
+                    {showPassword ? "👁" : "🙈"}
                   </button>
                 </div>
               </div>

--- a/Frontend/src/pages/RegisterUser/Index.jsx
+++ b/Frontend/src/pages/RegisterUser/Index.jsx
@@ -222,9 +222,9 @@ const RegisterUser = () => {
                     type="button"
                     className="password-toggle"
                     onClick={() => setShowPassword(!showPassword)}
-                    title={showPassword ? "Masquer le mot de passe" : "Afficher le mot de passe"}
+                    title={showPassword ? "Masquer" : "Afficher"}
                   >
-                    {showPassword ? "👁️" : "👁️‍🗨️"}
+                    {showPassword ? "👁" : "🙈"}
                   </button>
                 </div>
                 {formData.password && (
@@ -269,9 +269,9 @@ const RegisterUser = () => {
                     type="button"
                     className="password-toggle"
                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                    title={showConfirmPassword ? "Masquer le mot de passe" : "Afficher le mot de passe"}
+                    title={showConfirmPassword ? "Masquer" : "Afficher"}
                   >
-                    {showConfirmPassword ? "👁️" : "👁️‍🗨️"}
+                    {showConfirmPassword ? "👁" : "🙈"}
                   </button>
                 </div>
                 {formData.confirmPassword && formData.password !== formData.confirmPassword && (


### PR DESCRIPTION
## Summary
- replace `Annuler` text on cancel buttons by `✕`
- use simple `show/hide` titles and emoji icons for password fields

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in Backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848847aac14832dbc2ccc37429ce50e