### PR TITLE
Fix filtered stats endpoint

### DIFF
--- a/Backend/app.js
+++ b/Backend/app.js
@@ -15,6 +15,7 @@ const devisRoutes = require("./routes/devisRoutes");
 const businessCardRoutes = require("./routes/businessCardRoutes"); // ✅ NOUVEAU
 const subscriptionRoutes = require("./routes/subscriptionRoutes");
 const invoiceRoutes = require("./routes/invoiceRoutes"); // ✅ NOUVEAU
+const statsRoutes = require("./routes/statsRoutes");
 
 const app = express();
 
@@ -95,6 +96,7 @@ app.use("/api/devis", devisRoutes);
 app.use("/api/business-cards", businessCardRoutes); // ✅ NOUVEAU
 app.use("/api/subscription", subscriptionRoutes);
 app.use("/api/invoices", invoiceRoutes); // ✅ NOUVEAU
+app.use("/api/stats", statsRoutes);
 
 // ✅ Route de vérification du serveur
 app.get("/", (req, res) => {


### PR DESCRIPTION
## Summary
- implement `/api/stats` route
- filter statistics per authenticated user

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in Frontend *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684887d64918832d983b3fa8c3d26207