### PR TITLE
Add in-dashboard prospect form

### DIFF
--- a/Frontend/src/components/Dashboard/Prospects/prospectCreatePage.jsx
+++ b/Frontend/src/components/Dashboard/Prospects/prospectCreatePage.jsx
@@ -1,0 +1,195 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { API_ENDPOINTS, apiRequest } from '../../../config/api';
+import './prospectEdit.scss';
+
+const ProspectCreatePage = ({ userId, onBack, onCreated }) => {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    phone: '',
+    company: '',
+    address: '',
+    postalCode: '',
+    city: '',
+    notes: ''
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleInputChange = (field, value) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await apiRequest(API_ENDPOINTS.CLIENTS.REGISTER(userId), {
+        method: 'POST',
+        body: JSON.stringify(formData)
+      });
+      alert('✅ Prospect créé avec succès');
+      if (onCreated) {
+        onCreated();
+      } else {
+        navigate(-1);
+      }
+    } catch (err) {
+      console.error('Erreur création prospect:', err);
+      setError(err.message || 'Erreur lors de la création');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="prospect-edit-page in-dashboard">
+      <div className="edit-container">
+        <div className="edit-header">
+          <button onClick={onBack || (() => navigate(-1))} className="btn-back">
+            ← Retour
+          </button>
+          <div className="prospect-header-info">
+            <div className="prospect-avatar-large">+</div>
+            <div className="prospect-title">
+              <h1>Nouveau prospect</h1>
+              <p className="prospect-subtitle">Ajout manuel d'un prospect</p>
+            </div>
+          </div>
+        </div>
+
+        {error && (
+          <div className="error-container">
+            <p>❌ {error}</p>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="edit-form">
+          <div className="form-section">
+            <h3>📋 Informations principales</h3>
+            <div className="form-row">
+              <div className="form-group">
+                <label htmlFor="name">Nom complet *</label>
+                <input
+                  type="text"
+                  id="name"
+                  value={formData.name}
+                  onChange={(e) => handleInputChange('name', e.target.value)}
+                  required
+                  placeholder="Nom et prénom"
+                />
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="email">Email *</label>
+                <input
+                  type="email"
+                  id="email"
+                  value={formData.email}
+                  onChange={(e) => handleInputChange('email', e.target.value)}
+                  required
+                  placeholder="email@exemple.com"
+                />
+              </div>
+            </div>
+
+            <div className="form-row">
+              <div className="form-group">
+                <label htmlFor="phone">Téléphone *</label>
+                <input
+                  type="tel"
+                  id="phone"
+                  value={formData.phone}
+                  onChange={(e) => handleInputChange('phone', e.target.value)}
+                  required
+                  placeholder="06 12 34 56 78"
+                />
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="company">Entreprise</label>
+                <input
+                  type="text"
+                  id="company"
+                  value={formData.company}
+                  onChange={(e) => handleInputChange('company', e.target.value)}
+                  placeholder="Nom de l'entreprise"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="form-section">
+            <h3>📍 Adresse</h3>
+            <div className="form-group">
+              <label htmlFor="address">Adresse</label>
+              <input
+                type="text"
+                id="address"
+                value={formData.address}
+                onChange={(e) => handleInputChange('address', e.target.value)}
+                placeholder="Rue, numéro, bâtiment..."
+              />
+            </div>
+
+            <div className="form-row">
+              <div className="form-group">
+                <label htmlFor="postalCode">Code postal</label>
+                <input
+                  type="text"
+                  id="postalCode"
+                  value={formData.postalCode}
+                  onChange={(e) => handleInputChange('postalCode', e.target.value)}
+                  placeholder="75000"
+                  maxLength={5}
+                />
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="city">Ville</label>
+                <input
+                  type="text"
+                  id="city"
+                  value={formData.city}
+                  onChange={(e) => handleInputChange('city', e.target.value)}
+                  placeholder="Paris"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="form-section">
+            <h3>📝 Notes et commentaires</h3>
+            <div className="form-group">
+              <label htmlFor="notes">Notes internes</label>
+              <textarea
+                id="notes"
+                value={formData.notes}
+                onChange={(e) => handleInputChange('notes', e.target.value)}
+                placeholder="Notes sur le prospect, besoins, historique des échanges..."
+                rows={4}
+              />
+            </div>
+          </div>
+
+          <div className="form-actions">
+            <button
+              type="button"
+              onClick={onBack || (() => navigate(-1))}
+              className="btn-cancel"
+            >
+              Annuler
+            </button>
+            <button type="submit" className="btn-save" disabled={saving}>
+              {saving ? 'Enregistrement...' : '💾 Enregistrer'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ProspectCreatePage;

--- a/Frontend/src/components/Dashboard/Prospects/prospectsPage.jsx
+++ b/Frontend/src/components/Dashboard/Prospects/prospectsPage.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { API_ENDPOINTS, apiRequest } from '../../../config/api';
 import './prospects.scss';
 
-const ProspectsPage = ({ clients = [], onRefresh, onViewClientDevis, onEditProspect, onViewClientBilling }) => {
+const ProspectsPage = ({ clients = [], onRefresh, onViewClientDevis, onEditProspect, onViewClientBilling, onCreateProspect }) => {
   const navigate = useNavigate();
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
@@ -389,8 +389,8 @@ const ProspectsPage = ({ clients = [], onRefresh, onViewClientDevis, onEditProsp
               </button>
             )}
             
-            <button 
-              onClick={() => navigate("/register-client/" + userId)}
+            <button
+              onClick={onCreateProspect}
               className="cta-button"
             >
               ✨ Créer un prospect

--- a/Frontend/src/pages/Dashboard/Index.jsx
+++ b/Frontend/src/pages/Dashboard/Index.jsx
@@ -4,6 +4,7 @@ import Devis from "../../components/Dashboard/Devis/devisPage";
 import DevisListPage from "../../components/Dashboard/Devis/devisListPage";
 import ProspectsPage from "../../components/Dashboard/Prospects/prospectsPage";
 import ProspectEditPage from "../../components/Dashboard/Prospects/prospectEditPage";
+import ProspectCreatePage from "../../components/Dashboard/Prospects/prospectCreatePage";
 import ClientBilling from "../../components/Dashboard/ClientBilling/clientBilling";
 import Analytics from "../../components/Dashboard/Analytics/analytics";
 import Settings from "../../components/Dashboard/Settings/settings";
@@ -129,6 +130,11 @@ const Dashboard = () => {
     setActiveTab("clients");
   };
 
+  const handleCreateProspect = () => {
+    setSelectedProspect(null);
+    setActiveTab("prospect-create");
+  };
+
   const handleLogout = () => {
     localStorage.removeItem("token");
     localStorage.removeItem("user");
@@ -250,6 +256,7 @@ const Dashboard = () => {
       case "carte": return "Carte de Visite";
       case "settings": return "Paramètres";
       case "prospect-edit": return "Modification Prospect";
+      case "prospect-create": return "Nouveau Prospect";
       default: return "CRM Pro";
     }
   };
@@ -265,6 +272,7 @@ const Dashboard = () => {
       case "carte": return "💼";
       case "settings": return "⚙️";
       case "prospect-edit": return "✏️";
+      case "prospect-create": return "➕";
       default: return "📊";
     }
   };
@@ -293,8 +301,9 @@ const Dashboard = () => {
                     activeTab === item.id || 
                     (activeTab === "devis-creation" && item.id === "devis") ||
                     (activeTab === "prospect-edit" && item.id === "clients") ||
+                    (activeTab === "prospect-create" && item.id === "clients") ||
                     (activeTab === "client-billing" && item.id === "devis")
-                      ? "active" 
+                      ? "active"
                       : ""
                   }`}
                   onClick={() => {
@@ -305,7 +314,7 @@ const Dashboard = () => {
                       setSelectedClientForDevis(null);
                       setEditingDevis(null);
                     }
-                    if (item.id !== "clients" && item.id !== "prospect-edit") {
+                    if (item.id !== "clients" && item.id !== "prospect-edit" && item.id !== "prospect-create") {
                       setSelectedProspect(null);
                     }
                     if (item.id !== "client-billing") {
@@ -361,14 +370,14 @@ const Dashboard = () => {
                 🏠 Accueil
               </button>
               
-              <button 
+              <button
                 className="header-btn primary"
                 onClick={() => {
                   if (activeTab === "devis") {
                     handleCreateNewDevis();
                   } else if (activeTab === "clients") {
                     // Ajouter un nouveau prospect
-                    navigate("/register-client/" + userId);
+                    handleCreateProspect();
                   }
                 }}
               >
@@ -427,17 +436,18 @@ const Dashboard = () => {
             {activeTab === "dashboard" && <Analytics />}
 
             {activeTab === "clients" && (
-              <ProspectsPage 
+              <ProspectsPage
                 clients={clients}
                 onRefresh={fetchClients}
                 onViewClientDevis={handleViewClientDevis}
                 onViewClientBilling={handleViewClientBilling}
                 onEditProspect={handleEditProspect}
+                onCreateProspect={handleCreateProspect}
               />
             )}
 
             {activeTab === "prospect-edit" && selectedProspect && (
-              <ProspectEditPage 
+              <ProspectEditPage
                 prospect={selectedProspect}
                 onBack={() => {
                   setSelectedProspect(null);
@@ -446,6 +456,17 @@ const Dashboard = () => {
                 onSave={() => {
                   fetchClients();
                   setSelectedProspect(null);
+                  setActiveTab("clients");
+                }}
+              />
+            )}
+
+            {activeTab === "prospect-create" && (
+              <ProspectCreatePage
+                userId={userId}
+                onBack={() => setActiveTab("clients")}
+                onCreated={() => {
+                  fetchClients();
                   setActiveTab("clients");
                 }}
               />


### PR DESCRIPTION
## Summary
- add new `ProspectCreatePage` component
- allow creating prospects directly from dashboard
- wire new page into dashboard navigation and actions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848872b6eec832dabc5886a4802c17c