### PR TITLE
Fix registration token and trial

### DIFF
--- a/Backend/controllers/userController.js
+++ b/Backend/controllers/userController.js
@@ -29,20 +29,31 @@ exports.register = async (req, res) => {
       });
     }
 
-    const hashedPassword = await bcrypt.hash(password, 12);
-
-    const newUser = new User({ 
-      name: name.trim(), 
-      email: email.toLowerCase().trim(), 
-      password: hashedPassword 
+    const newUser = new User({
+      name: name.trim(),
+      email: email.toLowerCase().trim(),
+      password
     });
     
     await newUser.save();
 
+    // Generate JWT token for immediate authentication after registration
+    const token = jwt.sign(
+      { userId: newUser._id },
+      JWT_SECRET,
+      { expiresIn: JWT_EXPIRES_IN }
+    );
+
     console.log("✅ Nouvel utilisateur créé:", newUser.email);
-    res.status(201).json({ 
-      message: "Utilisateur inscrit avec succès",
-      userId: newUser._id 
+    // Return same structure as login so frontend can store token
+    res.status(201).json({
+      userId: newUser._id,
+      token,
+      user: {
+        id: newUser._id,
+        name: newUser.name,
+        email: newUser.email
+      }
     });
   } catch (error) {
     console.error("❌ Erreur lors de l'inscription:", error);


### PR DESCRIPTION
## Summary
- return auth token after registering a user so free trial can start
- rely on model pre-save hook for password hashing

## Testing
- `npm test --silent` *(backend)*
- `npm test --silent` *(frontend)*
- `npm run lint` *(frontend, fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68488dc8aff0832da53d81b20cfe2346