### PR TITLE
Add profile photo update feature

### DIFF
--- a/Backend/controllers/userController.js
+++ b/Backend/controllers/userController.js
@@ -52,7 +52,8 @@ exports.register = async (req, res) => {
       user: {
         id: newUser._id,
         name: newUser.name,
-        email: newUser.email
+        email: newUser.email,
+        profileImage: newUser.profileImage
       }
     });
   } catch (error) {
@@ -94,13 +95,14 @@ exports.login = async (req, res) => {
     );
 
     console.log("✅ Connexion réussie pour:", user.email);
-    res.status(200).json({ 
-      userId: user._id, 
+    res.status(200).json({
+      userId: user._id,
       token,
       user: {
         id: user._id,
         name: user.name,
-        email: user.email
+        email: user.email,
+        profileImage: user.profileImage
       }
     });
   } catch (error) {
@@ -125,6 +127,7 @@ exports.getUser = async (req, res) => {
       userId: user._id,
       name: user.name,
       email: user.email,
+      profileImage: user.profileImage,
     });
   } catch (error) {
     console.error("❌ Erreur lors de la récupération de l'utilisateur:", error);
@@ -236,5 +239,40 @@ exports.changePassword = async (req, res) => {
     res.status(500).json({ 
       message: "Erreur lors du changement de mot de passe" 
     });
+  }
+};
+
+exports.updateProfilePicture = async (req, res) => {
+  try {
+    const { profileImage } = req.body;
+    const userId = req.userId;
+
+    if (!profileImage) {
+      return res.status(400).json({
+        message: "Image requise"
+      });
+    }
+
+    const updatedUser = await User.findByIdAndUpdate(
+      userId,
+      { profileImage },
+      { new: true, select: '-password' }
+    );
+
+    if (!updatedUser) {
+      return res.status(404).json({ message: 'Utilisateur non trouvé' });
+    }
+
+    console.log('✅ Photo de profil mise à jour pour:', updatedUser.email);
+    res.status(200).json({
+      message: 'Photo de profil mise à jour',
+      user: {
+        userId: updatedUser._id,
+        profileImage: updatedUser.profileImage
+      }
+    });
+  } catch (error) {
+    console.error('❌ Erreur lors de la mise à jour de la photo de profil:', error);
+    res.status(500).json({ message: "Erreur lors de la mise à jour de la photo de profil" });
   }
 };

--- a/Backend/models/user.js
+++ b/Backend/models/user.js
@@ -48,6 +48,10 @@ const UserSchema = new mongoose.Schema({
   hasHadTrial: {
     type: Boolean,
     default: false
+  },
+  profileImage: {
+    type: String,
+    default: ''
   }
 });
 

--- a/Backend/routes/userRoutes.js
+++ b/Backend/routes/userRoutes.js
@@ -1,10 +1,11 @@
 const express = require("express");
-const { 
-  register, 
-  login, 
-  getUser, 
-  updateProfile, 
-  changePassword 
+const {
+  register,
+  login,
+  getUser,
+  updateProfile,
+  changePassword,
+  updateProfilePicture
 } = require("../controllers/userController");
 const authenticate = require("../middleware/auth");
 
@@ -24,5 +25,8 @@ router.put("/profile", authenticate, updateProfile);
 
 // Route protégée pour changer le mot de passe
 router.put("/password", authenticate, changePassword);
+
+// Route protégée pour changer la photo de profil
+router.put("/profile-picture", authenticate, updateProfilePicture);
 
 module.exports = router;

--- a/Frontend/src/components/Navbar/index.jsx
+++ b/Frontend/src/components/Navbar/index.jsx
@@ -133,7 +133,11 @@ const Navbar = () => {
               {/* Profil utilisateur */}
               <div className="user-profile" onClick={toggleUserMenu} ref={userMenuRef}>
                 <div className="user-avatar">
-                  {user?.name ? user.name.charAt(0).toUpperCase() : "U"}
+                  {user?.profileImage ? (
+                    <img src={user.profileImage} alt="Profil" />
+                  ) : (
+                    user?.name ? user.name.charAt(0).toUpperCase() : 'U'
+                  )}
                 </div>
                 <div className="user-info">
                   <span className="user-name">{user?.name || "Utilisateur"}</span>
@@ -147,7 +151,11 @@ const Navbar = () => {
                 >
                   <div className="user-menu-header">
                     <div className="menu-avatar">
-                      {user?.name ? user.name.charAt(0).toUpperCase() : "U"}
+                      {user?.profileImage ? (
+                        <img src={user.profileImage} alt="Profil" />
+                      ) : (
+                        user?.name ? user.name.charAt(0).toUpperCase() : 'U'
+                      )}
                     </div>
                     <h3 className="menu-user-name">{user?.name || "Utilisateur"}</h3>
                     <p className="menu-user-email">{user?.email || ""}</p>

--- a/Frontend/src/components/Navbar/navbar.scss
+++ b/Frontend/src/components/Navbar/navbar.scss
@@ -178,6 +178,13 @@
   font-size: 1rem;
   color: white;
   box-shadow: 0 4px 15px rgba(251, 191, 36, 0.3);
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
 }
 
 .user-info {
@@ -243,6 +250,13 @@
   color: white;
   margin: 0 auto 1rem;
   box-shadow: 0 8px 25px rgba(245, 158, 11, 0.3);
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
 }
 
 .menu-user-name {

--- a/Frontend/src/config/api.js
+++ b/Frontend/src/config/api.js
@@ -15,6 +15,7 @@ export const API_ENDPOINTS = {
     ME: `${API_CONFIG.BASE_URL}/users/me`,
     UPDATE_PROFILE: `${API_CONFIG.BASE_URL}/users/profile`,
     CHANGE_PASSWORD: `${API_CONFIG.BASE_URL}/users/password`,
+    UPDATE_PROFILE_PICTURE: `${API_CONFIG.BASE_URL}/users/profile-picture`,
   },
   
   // Clients

--- a/Frontend/src/pages/Dashboard/Index.jsx
+++ b/Frontend/src/pages/Dashboard/Index.jsx
@@ -374,7 +374,11 @@ const Dashboard = () => {
             
             <div className="user-profile" onClick={toggleUserMenu} ref={userMenuRef}>
               <div className="user-avatar">
-                {user.name ? user.name.charAt(0).toUpperCase() : "U"}
+                {user.profileImage ? (
+                  <img src={user.profileImage} alt="Profil" />
+                ) : (
+                  user.name ? user.name.charAt(0).toUpperCase() : 'U'
+                )}
               </div>
               <div className="user-info">
                 <span className="user-name">{user.name || "Utilisateur"}</span>
@@ -385,7 +389,11 @@ const Dashboard = () => {
               <div className={`user-menu ${isUserMenuOpen ? 'active' : ''}`}>
                 <div className="user-menu-header">
                   <div className="menu-avatar">
-                    {user.name ? user.name.charAt(0).toUpperCase() : "U"}
+                    {user.profileImage ? (
+                      <img src={user.profileImage} alt="Profil" />
+                    ) : (
+                      user.name ? user.name.charAt(0).toUpperCase() : 'U'
+                    )}
                   </div>
                   <h3 className="menu-user-name">{user.name || "Utilisateur"}</h3>
                   <p className="menu-user-email">{user.email || ""}</p>

--- a/Frontend/src/pages/Dashboard/dashboard.scss
+++ b/Frontend/src/pages/Dashboard/dashboard.scss
@@ -358,6 +358,13 @@
   font-size: 1rem;
   color: white;
   box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
 }
 
 .user-info {
@@ -521,6 +528,13 @@
   color: white;
   margin: 0 auto 1rem;
   box-shadow: 0 8px 25px rgba(245, 158, 11, 0.3);
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
 }
 
 .menu-user-name {

--- a/Frontend/src/pages/Settings/Index.jsx
+++ b/Frontend/src/pages/Settings/Index.jsx
@@ -13,6 +13,7 @@ const Settings = () => {
   const [formData, setFormData] = useState({
     name: '',
     email: '',
+    profileImage: '',
     currentPassword: '',
     newPassword: '',
     confirmPassword: ''
@@ -33,7 +34,8 @@ const Settings = () => {
       setFormData(prev => ({
         ...prev,
         name: userData.name || '',
-        email: userData.email || ''
+        email: userData.email || '',
+        profileImage: userData.profileImage || ''
       }));
     } catch (error) {
       console.error('Erreur lors du chargement des données utilisateur:', error);
@@ -55,6 +57,35 @@ const Settings = () => {
       ...prev,
       [name]: value
     }));
+  };
+
+  const handleProfileImageChange = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setFormData(prev => ({ ...prev, profileImage: reader.result }));
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleProfileImageUpload = async (e) => {
+    e.preventDefault();
+    if (!formData.profileImage) return;
+    setLoading(true);
+    setMessage('');
+    try {
+      await apiRequest(API_ENDPOINTS.AUTH.UPDATE_PROFILE_PICTURE, {
+        method: 'PUT',
+        body: JSON.stringify({ profileImage: formData.profileImage })
+      });
+      setMessage('✅ Photo de profil mise à jour');
+      fetchUserData();
+    } catch (error) {
+      setMessage(`❌ Erreur: ${error.message}`);
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleProfileUpdate = async (e) => {
@@ -330,7 +361,7 @@ const Settings = () => {
                 required
               />
             </div>
-            
+
             <div className="form-group">
               <label htmlFor="email">Email</label>
               <input
@@ -342,7 +373,23 @@ const Settings = () => {
                 required
               />
             </div>
-            
+
+            <div className="form-group">
+              <label htmlFor="profileImage">Photo de profil</label>
+              <input
+                type="file"
+                id="profileImage"
+                accept="image/*"
+                onChange={handleProfileImageChange}
+              />
+              {formData.profileImage && (
+                <img src={formData.profileImage} alt="Aperçu" className="profile-preview" />
+              )}
+              <button onClick={handleProfileImageUpload} disabled={loading || !formData.profileImage} style={{marginTop:'0.5rem'}}>
+                {loading ? 'Envoi...' : 'Mettre à jour la photo'}
+              </button>
+            </div>
+
             <button type="submit" disabled={loading}>
               {loading ? 'Mise à jour...' : 'Mettre à jour le profil'}
             </button>

--- a/Frontend/src/pages/Settings/settings.scss
+++ b/Frontend/src/pages/Settings/settings.scss
@@ -220,6 +220,14 @@
   background: linear-gradient(135deg, #059669 0%, #047857 100%) !important;
 }
 
+.profile-preview {
+  margin-top: 0.5rem;
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
 .help-text {
   color: #64748b;
   font-size: 14px;


### PR DESCRIPTION
## Summary
- allow storing a profile image for each user
- expose new backend route to update a user's profile picture
- send profile image in auth responses and on `/me`
- adjust API config for new route
- update settings page to upload & preview profile picture
- display profile image on dashboard and navbar
- style avatar images

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` in Frontend *(fails: vite not found)*
- `npm test` in Backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68488d91729c832d82d3912fcd51a632